### PR TITLE
Workaround for .tt blobs >1MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ __pycache__
 */ghostdriver.log
 */django_logger.log
 **/secrets.py
+**.pyc
 
 # --------------------
 # Env Files

--- a/coptic/coptic/settings/base.py
+++ b/coptic/coptic/settings/base.py
@@ -120,6 +120,7 @@ TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
 # SCRIPTORIUM-specific config
 CORPUS_REPO_OWNER = "CopticScriptorium"
 CORPUS_REPO_NAME  = "corpora"
+GITHUB_API_BASE_URL = "https://api.github.com"
 
 DEPRECATED_URNS = {
 	"urn:cts:copticLit:shenoute.a22.monbyb_307_320": "urn:cts:copticLit:shenoute.a22.monbyb:801-825",


### PR DESCRIPTION
github3.py, which we use for GitHub integration in the scraper, doesn't support blobs >1MB in size, at least in some of its API's. This is a workaround for .tt blobs. Will fail on other filetypes if they are over that limit, but at the moment .tt files are most liable to be >1MB in size.