### PR TITLE
Minimal cache implementation

### DIFF
--- a/coptic/coptic/settings/base.py
+++ b/coptic/coptic/settings/base.py
@@ -33,18 +33,16 @@ INSTALLED_APPS = (
 	'mod_wsgi.server'
 )
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
 	'django.contrib.sessions.middleware.SessionMiddleware',
 	'django.middleware.common.CommonMiddleware',
 	'django.middleware.csrf.CsrfViewMiddleware',
 	'django.contrib.auth.middleware.AuthenticationMiddleware',
 	'django.contrib.messages.middleware.MessageMiddleware',
 	'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.cache.UpdateCacheMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 ]
-if django.VERSION[0] < 2:
-	MIDDLEWARE_CLASSES.append('django.contrib.auth.middleware.SessionAuthenticationMiddleware')
-MIDDLEWARE = MIDDLEWARE_CLASSES # for django >= 1.10
-
 
 # for newer django
 TEMPLATES = [
@@ -61,11 +59,6 @@ TEMPLATES = [
 	}
 ]
 
-# for older django
-TEMPLATE_CONTEXT_PROCESSORS = (
-	"django.core.context_processors.request",
-	"django.contrib.auth.context_processors.auth"
-)
 
 ROOT_URLCONF = 'coptic.urls'
 
@@ -104,6 +97,13 @@ LOGGING = {
 	   	 'level': 'INFO',
 	    },
 	}
+}
+# Cache configuration
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_cache',
+    }
 }
 
 # Internationalization

--- a/coptic/coptic/views.py
+++ b/coptic/coptic/views.py
@@ -5,6 +5,8 @@ from django.urls import reverse
 from django.db.models import Q, Case, When, IntegerField, F
 from django.shortcuts import render, get_object_or_404, redirect
 from django.db.models.functions import Lower
+from django.views.decorators.cache import cache_page
+from django.core.cache import cache
 from texts.search_fields import get_search_fields
 from coptic.settings.base import DEPRECATED_URNS
 from collections import OrderedDict
@@ -19,12 +21,13 @@ from django.template.defaulttags import register
 def keyvalue(dict, key):
     return dict.get(key)
 
+@cache_page(60 * 15)
 def home_view(request):
     'Home'
     context = _base_context()
     return render(request, 'home.html', context)
 
-
+@cache_page(60 * 15)
 def corpus_view(request, corpus=None):
     corpus_object = get_object_or_404(models.Corpus, slug=corpus)
 
@@ -64,7 +67,7 @@ def corpus_view(request, corpus=None):
     })
     return render(request, 'corpus.html', context)
 
-
+@cache_page(60 * 15)
 def text_view(request, corpus=None, text=None, format=None):
     text_object = get_object_or_404(models.Text, slug=text)
     if not format:
@@ -157,7 +160,7 @@ def get_meta_values(meta):
     meta_values = [re.sub(HTML_TAG_REGEX, '', meta_value) for meta_value in meta_values]
     return meta_values
 
-
+@cache_page(60 * 15)
 def index_view(request, special_meta=None):
     context = _base_context()
 


### PR DESCRIPTION
Here we add some minimal file-based caching for the main routes in the views of the app. 
This is very conservative and should not change any behavior.
The cache is set to got to `/tmp/django_cache`.
There is a minor change to base.py to add the caching middlewares. We use this occasion to cleanup the unnecessary Django 1.0 elements.
Please do test before putting into production. 
